### PR TITLE
Changed meta pkg v1.9.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.3
-  meta: ^1.10.0
+  meta: ^1.9.1
   
 dev_dependencies:
   very_good_analysis: ^5.1.0


### PR DESCRIPTION
I changed meta pkg v1.9.1 Because when add this pkg to mobile app, I gave error 
```error
Because every version of flutter_test from sdk depends on meta 1.9.1 and every version of jdenticon_dart from git depends on meta ^1.10.0, flutter_test from sdk is incompatible with jdenticon_dart from git.
So, because mydatacoin depends on both jdenticon_dart from git and flutter_test from sdk, version solving failed.
exit code 1
```